### PR TITLE
Update or save music after import 

### DIFF
--- a/src/infra/db/Sqlite/entities/PlaylistEntity.ts
+++ b/src/infra/db/Sqlite/entities/PlaylistEntity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, ManyToOne, OneToMany } from 'typeorm'
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, ManyToOne, OneToMany, Index } from 'typeorm'
 
 import { Playlist } from '../../../../modules/music/entities/Playlist'
 import { UserEntity } from './UserEntity'
@@ -6,10 +6,11 @@ import { TrackEntity } from './TrackEntity'
 import { StreamingEntity } from './StreamingEntity'
 
 @Entity()
+@Index(['external_id', 'streaming'], { unique: true })
 export class PlaylistEntity extends BaseEntity implements Playlist {
   @PrimaryGeneratedColumn()
   id: number
-  @Column()
+  @Column({ unique: true })
   external_id: string
   @Column()
   name: string

--- a/src/infra/db/Sqlite/entities/TrackEntity.ts
+++ b/src/infra/db/Sqlite/entities/TrackEntity.ts
@@ -1,14 +1,15 @@
-import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, ManyToOne } from 'typeorm'
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, ManyToOne, Index } from 'typeorm'
 
 import { Track } from '../../../../modules/music/entities/Track'
 import { PlaylistEntity } from './PlaylistEntity'
 import { StreamingEntity } from './StreamingEntity'
 
 @Entity()
+@Index(['external_id', 'playlist'], { unique: true })
 export class TrackEntity extends BaseEntity implements Track {
   @PrimaryGeneratedColumn()
   id: number
-  @Column({ type: 'text' })
+  @Column({ type: 'text', unique: true })
   external_id: string
   @Column()
   name: string

--- a/src/infra/db/Sqlite/repositories/PlaylistRepository.ts
+++ b/src/infra/db/Sqlite/repositories/PlaylistRepository.ts
@@ -128,7 +128,7 @@ export class PlaylistRepository implements IPlaylistRepository {
       return 0
     }
 
-    return result.raw
+    return result.generatedMaps.length
   }
 
   private async getPlaylistRelations(data: { userId: number, streamingId: number }) {

--- a/src/infra/db/Sqlite/repositories/PlaylistRepository.ts
+++ b/src/infra/db/Sqlite/repositories/PlaylistRepository.ts
@@ -28,17 +28,17 @@ export class PlaylistRepository implements IPlaylistRepository {
       return []
     }
 
-    const [user, streaming] = await Promise.all([
-      this.userRepository.findOneBy({ id: playlistData[0]?.userId }),
-      this.streamingRepository.findOneBy({ id: playlistData[0]?.streamingId }),
-    ])
+    const { user, streaming } = await this.getPlaylistRelations({
+      streamingId: playlistData[0].streamingId,
+      userId: playlistData[0].userId,
+    })
 
     if (!user || !streaming) {
       return []
     }
 
     const playlists = playlistData.map((playlist) =>
-      this._createPlaylist({
+      this.convertPlaylist({
         user,
         streaming,
         playlistData: playlist,
@@ -55,20 +55,16 @@ export class PlaylistRepository implements IPlaylistRepository {
   }
 
   async createPlaylist(playlistData: CreatePlaylistDTO) {
-    const [user, streaming] = await Promise.all([
-      this.userRepository.findOneBy({ id: playlistData.userId }),
-      this.streamingRepository.findOneBy({ id: playlistData.streamingId }),
-    ])
+    const { user, streaming } = await this.getPlaylistRelations({
+      streamingId: playlistData.streamingId,
+      userId: playlistData.userId,
+    })
 
     if (!user || !streaming) {
       return null
     }
 
-    const playlist = new PlaylistEntity()
-    playlist.name = playlistData.name
-    playlist.external_id = playlistData.externalId
-    playlist.user = user
-    playlist.streaming = streaming
+    const playlist = this.convertPlaylist({ user, streaming, playlistData })
 
     const newPlaylist = await this.repository.save(playlist)
 
@@ -108,7 +104,43 @@ export class PlaylistRepository implements IPlaylistRepository {
     return this.entityConverter.from(playlist)
   }
 
-  private _createPlaylist({
+  async upsertPlaylists(playlistData: CreatePlaylistDTO[]): Promise<number> {
+    if (!playlistData.length) {
+      return 0
+    }
+
+    const { user, streaming } = await this.getPlaylistRelations({
+      streamingId: playlistData[0].streamingId,
+      userId: playlistData[0].userId,
+    })
+
+    if (!user || !streaming) {
+      return 0
+    }
+
+    const convertedPlaylists = playlistData.map((playlist) =>
+      this.convertPlaylist({ user, streaming, playlistData: playlist }),
+    )
+
+    const result = await this.repository.upsert(convertedPlaylists, ['external_id', 'streaming'])
+
+    if (!result) {
+      return 0
+    }
+
+    return result.raw
+  }
+
+  private async getPlaylistRelations(data: { userId: number, streamingId: number }) {
+    const [user, streaming] = await Promise.all([
+      this.userRepository.findOneBy({ id: data.userId }),
+      this.streamingRepository.findOneBy({ id: data.streamingId }),
+    ])
+
+    return { user, streaming }
+  }
+
+  private convertPlaylist({
     user,
     streaming,
     playlistData,

--- a/src/modules/music/interfaces/IPlaylistRepository.ts
+++ b/src/modules/music/interfaces/IPlaylistRepository.ts
@@ -4,6 +4,7 @@ import { CreatePlaylistDTO } from '../dtos/CreatePlaylistDTO'
 export interface IPlaylistRepository {
   createPlaylist(playlistData: CreatePlaylistDTO): Promise<Playlist | null>,
   createPlaylists(playlistData: CreatePlaylistDTO[]): Promise<Playlist[]>,
+  upsertPlaylists(playlistData: CreatePlaylistDTO[]): Promise<number>,
   getPlaylistByExternalId(externalId: string): Promise<Playlist | null>,
   getPlaylistById(id: number): Promise<Playlist | null>,
   getPlaylistsByUserId(userId: number): Promise<Playlist[]>,

--- a/src/modules/music/interfaces/ITracksRepository.ts
+++ b/src/modules/music/interfaces/ITracksRepository.ts
@@ -4,8 +4,9 @@ import { Track } from '../entities/Track'
 export interface ITracksRepository {
   createTrack(tracks: CreateTrackDTO): Promise<Track | null>,
   createTracks(tracks: CreateTrackDTO[]): Promise<Track[]>,
-  // getTrackById(id: number): Promise<Track | null>,
+  upsertTracks(tracks: CreateTrackDTO[]): Promise<number>,
   getTracksByPlaylistId(playlistId: number): Promise<Track[]>,
+  getTracksByUserId(id: number): Promise<Track[]>,
   // createTracks(tracks: CreateTrackDTO[]): boolean,
   // getTracksByExternalIds(externalIds: string[]): Promise<Track[]>,
   // getTracksByExternalId(externalId: string): Promise<Track[]>,

--- a/src/modules/music/syncronization/MusicImporter.ts
+++ b/src/modules/music/syncronization/MusicImporter.ts
@@ -103,9 +103,9 @@ export class MusicImporter implements IMusicImporter {
       }
 
       const tracksData = chunk.map((t) => t.toCreate({ userId, playlistId }))
-      const savedTracks = await this.trackRepository.createTracks(tracksData)
+      const savedTracks = await this.trackRepository.upsertTracks(tracksData)
 
-      counter.saved += savedTracks.length
+      counter.saved += savedTracks
       counter.exported += chunk.length
       offset += step
     }

--- a/src/modules/music/syncronization/MusicImporter.ts
+++ b/src/modules/music/syncronization/MusicImporter.ts
@@ -47,9 +47,9 @@ export class MusicImporter implements IMusicImporter {
       }
 
       const playlistsData = chunk.map((p) => p.toCreate({ userId, streamingId }))
-      const savedPlaylists = await this.playlistRepository.createPlaylists(playlistsData)
+      const savedPlaylists = await this.playlistRepository.upsertPlaylists(playlistsData)
 
-      counter.saved += savedPlaylists.length
+      counter.saved += savedPlaylists
       counter.exported += chunk.length
       offset += step
     }

--- a/src/test/services/playlist.test.ts
+++ b/src/test/services/playlist.test.ts
@@ -135,4 +135,28 @@ describe('Playlist service tests', () => {
     expect(exportResult).toEqual({ exported: PLAYLISTS, saved: PLAYLISTS })
     expect(exportResult.exported).toBe(exportResult.saved)
   })
+
+  test('Re-exporting playlists does not create duplicates', async () => {
+    if (isServiceError(currentUser)) {
+      throw Error('User not created')
+    }
+
+    const streaming = await streamingService.createStreaming(testStreamingDTO(currentUser.id))
+
+    if (isServiceError(streaming)) {
+      throw Error('Streaming not created')
+    }
+
+    const exportData = new ImportMediaDTO({
+      streamingType: EStreamingType.SPOTIFY,
+      userId: currentUser.id,
+    })
+
+    await playlistService.importPlaylists(exportData)
+
+    const exportResult = (await playlistService.importPlaylists(exportData)) as any
+    const totalPlaylists = (await playlistService.getUserPlaylists(currentUser.id)) as any
+
+    expect(totalPlaylists.length).toBe(exportResult.exported)
+  })
 })


### PR DESCRIPTION
This pull request aims to implement a functionality that updates existing music records if they are already present in the database, and creates new records for those that are not. When importing music into the system, it will check if each track already exists in the database. If it does, the system will update the existing record with the latest information. If the track is not found in the database, a new entry will be created, ensuring comprehensive coverage of all imported music.